### PR TITLE
Enable default network look-up

### DIFF
--- a/handlers/delete.go
+++ b/handlers/delete.go
@@ -39,7 +39,7 @@ func DeleteHandler(c *client.Client) http.HandlerFunc {
 
 		services, err := c.ServiceList(context.Background(), options)
 		if err != nil {
-			fmt.Println(err)
+			log.Printf("Error listing services: %s\n", err)
 		}
 
 		// TODO: Filter only "faas" functions (via metadata?)
@@ -52,7 +52,6 @@ func DeleteHandler(c *client.Client) http.HandlerFunc {
 			}
 		}
 
-		log.Println(len(serviceIDs))
 		if len(serviceIDs) == 0 {
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte(fmt.Sprintf("No such service found: %s.", req.FunctionName)))

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -55,7 +55,8 @@ func DeployHandler(c *client.Client, maxRestarts uint64, restartDelay time.Durat
 
 		secrets, err := makeSecretsArray(c, request.Secrets)
 		if err != nil {
-			log.Println(err)
+			log.Printf("Deployment error: %s\n", err)
+
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte("Deployment error: " + err.Error()))
 			return
@@ -64,7 +65,7 @@ func DeployHandler(c *client.Client, maxRestarts uint64, restartDelay time.Durat
 		if len(request.Network) == 0 {
 			networkValue, networkErr := lookupNetwork(c)
 			if networkErr != nil {
-				log.Println("Error querying networks", networkErr)
+				log.Printf("Error querying networks: %s\n", networkErr)
 			} else {
 				request.Network = networkValue
 			}
@@ -74,12 +75,17 @@ func DeployHandler(c *client.Client, maxRestarts uint64, restartDelay time.Durat
 
 		response, err := c.ServiceCreate(context.Background(), spec, options)
 		if err != nil {
-			log.Println("Error creating service:", err)
+
+			log.Printf("Error creating service: %s\n", err)
+
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte("Deployment error: " + err.Error()))
 			return
 		}
-		log.Println(response.ID, response.Warnings)
+
+		if len(response.Warnings) > 0 {
+			log.Println(response.Warnings)
+		}
 	}
 }
 

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -47,7 +47,6 @@ func FunctionProxy(wildcard bool, client *client.Client) http.HandlerFunc {
 
 		switch r.Method {
 		case "POST", "GET":
-			// log.Print(r.Header)
 
 			xFunctionHeader := r.Header["X-Function"]
 			if len(xFunctionHeader) > 0 {
@@ -57,10 +56,9 @@ func FunctionProxy(wildcard bool, client *client.Client) http.HandlerFunc {
 			// getServiceName
 			var serviceName string
 			if wildcard {
-				vars := mux.Vars(r)
-				// fmt.Println("vars ", vars)
+				muxVars := mux.Vars(r)
 
-				name := vars["name"]
+				name := muxVars["name"]
 				serviceName = name
 			} else if len(xFunctionHeader) > 0 {
 				serviceName = xFunctionHeader[0]
@@ -142,7 +140,8 @@ func invokeService(w http.ResponseWriter, r *http.Request, service string, forwa
 
 	response, err := proxyClient.Do(request)
 	if err != nil {
-		log.Print(err)
+		log.Printf("Error, can't reach service: %s, %s\n", service, err)
+
 		writeHead(service, http.StatusInternalServerError, w)
 		buf := bytes.NewBufferString("Can't reach service: " + service)
 		w.Write(buf.Bytes())

--- a/handlers/reader.go
+++ b/handlers/reader.go
@@ -22,6 +22,8 @@ func FunctionReader(wildcard bool, c client.ServiceAPIClient) http.HandlerFunc {
 
 		functions, err := readServices(c)
 		if err != nil {
+			log.Printf("Error getting service list: %s\n", err.Error())
+
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))
 			return
@@ -31,7 +33,6 @@ func FunctionReader(wildcard bool, c client.ServiceAPIClient) http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(functionBytes)
-
 	}
 }
 
@@ -45,8 +46,6 @@ func readServices(c client.ServiceAPIClient) ([]requests.Function, error) {
 
 	services, err := c.ServiceList(context.Background(), options)
 	if err != nil {
-		log.Printf("Error getting service list: %s", err.Error())
-
 		return functions, fmt.Errorf("error getting service list: %s", err.Error())
 	}
 

--- a/handlers/replicas_updater.go
+++ b/handlers/replicas_updater.go
@@ -13,11 +13,13 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// ScaleServiceRequest request to scale a function
 type ScaleServiceRequest struct {
 	ServiceName string `json:"serviceName"`
 	Replicas    uint64 `json:"replicas"`
 }
 
+// ReplicaUpdater updates a function
 func ReplicaUpdater(c *client.Client) http.HandlerFunc {
 	serviceQuery := NewSwarmServiceQuery(c)
 
@@ -26,17 +28,22 @@ func ReplicaUpdater(c *client.Client) http.HandlerFunc {
 		vars := mux.Vars(r)
 		functionName := vars["name"]
 
+		log.Printf("ReplicaUpdater - updating function: %s\n", functionName)
+
 		req := ScaleServiceRequest{}
 
 		if r.Body != nil {
 			defer r.Body.Close()
+
 			bytesIn, _ := ioutil.ReadAll(r.Body)
 			marshalErr := json.Unmarshal(bytesIn, &req)
 			if marshalErr != nil {
-				w.WriteHeader(http.StatusBadRequest)
 				msg := "Cannot parse request. Please pass valid JSON."
-				w.Write([]byte(msg))
+
 				log.Println(msg, marshalErr)
+
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(msg))
 				return
 			}
 		}

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -54,6 +54,15 @@ func UpdateHandler(c *client.Client, maxRestarts uint64, restartDelay time.Durat
 			return
 		}
 
+		if len(request.Network) == 0 {
+			networkValue, networkErr := lookupNetwork(c)
+			if networkErr != nil {
+				log.Println("Error querying networks", networkErr)
+			} else {
+				request.Network = networkValue
+			}
+		}
+
 		updateSpec(&request, &service.Spec, maxRestarts, restartDelay, secrets)
 
 		updateOpts := types.ServiceUpdateOptions{}

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -86,7 +86,9 @@ func UpdateHandler(c *client.Client, maxRestarts uint64, restartDelay time.Durat
 			w.Write([]byte("Update error: " + err.Error()))
 			return
 		}
-		log.Println(response.Warnings)
+		if response.Warnings != nil {
+			log.Println(response.Warnings)
+		}
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -24,7 +23,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error with Docker client: %s.", err.Error())
 	}
-	fmt.Println(dockerClient)
 
 	dockerVersion, versionErr := dockerClient.ServerVersion(context.Background())
 	if versionErr != nil {
@@ -56,12 +54,10 @@ func main() {
 		Health:         handlers.Health(),
 	}
 
-	var port int
-	port = 8080
 	bootstrapConfig := bootTypes.FaaSConfig{
 		ReadTimeout:  cfg.ReadTimeout,
 		WriteTimeout: cfg.WriteTimeout,
-		TCPPort:      &port,
+		TCPPort:      &cfg.TCPPort,
 	}
 
 	bootstrap.Serve(&bootstrapHandlers, &bootstrapConfig)

--- a/test/read_config_test.go
+++ b/test/read_config_test.go
@@ -43,6 +43,26 @@ func TestRead_EmptyTimeoutConfig(t *testing.T) {
 		t.Logf("WriteTimeout want: %s, got %s", defaultVal.String(), config.ReadTimeout.String())
 		t.Fail()
 	}
+
+	if (config.TCPPort) != 8080 {
+		t.Logf("TCPPort want: %d, got %d", 8080, config.TCPPort)
+		t.Fail()
+	}
+}
+
+func TestRead_TCPPortOverrideConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	defaults.Setenv("port", "8081")
+	readConfig := types.ReadConfig{}
+
+	config := readConfig.Read(defaults)
+
+	expected := 8081
+
+	if (config.TCPPort) != expected {
+		t.Logf("TCPPort want: %d, got %d", expected, config.TCPPort)
+		t.Fail()
+	}
 }
 
 func TestRead_ReadAndWriteIntegerTimeoutConfig(t *testing.T) {

--- a/types/read_config.go
+++ b/types/read_config.go
@@ -26,6 +26,16 @@ type HasEnv interface {
 type ReadConfig struct {
 }
 
+func parseIntValue(val string, fallback int) int {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return parsedVal
+		}
+	}
+	return fallback
+}
+
 func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
 	if len(val) > 0 {
 		parsedVal, parseErr := strconv.Atoi(val)
@@ -56,6 +66,9 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 	readTimeout := parseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*10)
 	writeTimeout := parseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*10)
 
+	const defaultPort = 8080
+
+	cfg.TCPPort = parseIntValue(hasEnv.Getenv("port"), defaultPort)
 	cfg.ReadTimeout = readTimeout
 	cfg.WriteTimeout = writeTimeout
 
@@ -66,4 +79,5 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 type BootstrapConfig struct {
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
+	TCPPort      int
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Enables default network look-up

## Motivation and Context

Idea has been raised by community several times - if the deployment network is non-default i.e `docker stack deploy` uses a different stack name - then the network cannot be guessed or left blank.

This change lets us have an empty network value in the UI for the store. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Altering the network to add a label of openfaas=true

```
networks:
    functions:
        driver: overlay
        attachable: true
        labels:
         - "openfaas=true"
```

This used to fail:

```
faas deploy --image=functions/alpine:latest --fprocess="cat" --network="" --name tester
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
