### PR TITLE
Fix - read Docker passwords from stdin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ after_success:
         fi
     - if [ ! -z "$TRAVIS_TAG" ] ; then 
 
-	echo "Travis tag: $TRAVIS_TAG"
+        echo "Travis tag: $TRAVIS_TAG"
 
         docker tag $DOCKER_NS/faas-swarm:latest-dev $DOCKER_NS/faas-swarm:$TRAVIS_TAG;
-        docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD;
+        echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
         docker push $DOCKER_NS/faas-swarm:$TRAVIS_TAG;
 
         docker tag $DOCKER_NS/faas-swarm:latest-dev quay.io/$DOCKER_NS/faas-swarm:$TRAVIS_TAG;


### PR DESCRIPTION
Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

Docker CLI now mandates passwords are passed-in via stdin. This
change updates `docker login` to address the new requirement.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
[#650](https://github.com/openfaas/faas/issues/650)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.