### PR TITLE
Move secrets mount path to /var/openfaas/secrets

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/cli/opts"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -331,66 +330,4 @@ func getMinReplicas(request *requests.CreateFunctionRequest) *uint64 {
 		}
 	}
 	return &replicas
-}
-
-func makeSecretsArray(c *client.Client, secretNames []string) ([]*swarm.SecretReference, error) {
-	values := []*swarm.SecretReference{}
-
-	if len(secretNames) == 0 {
-		return values, nil
-	}
-
-	secretOpts := new(opts.SecretOpt)
-	for _, secret := range secretNames {
-		if err := secretOpts.Set(secret); err != nil {
-			return nil, err
-		}
-	}
-
-	requestedSecrets := make(map[string]bool)
-	ctx := context.Background()
-
-	// query the Swarm for the requested secret ids, these are required to complete
-	// the spec
-	args := filters.NewArgs()
-	for _, opt := range secretOpts.Value() {
-		args.Add("name", opt.SecretName)
-	}
-
-	secrets, err := c.SecretList(ctx, types.SecretListOptions{
-		Filters: args,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// create map of matching secrets for easy lookup
-	foundSecrets := make(map[string]string)
-	for _, secret := range secrets {
-		foundSecrets[secret.Spec.Annotations.Name] = secret.ID
-	}
-
-	// mimics the simple syntax for `docker service create --secret foo`
-	// and the code is based on the docker cli
-	for _, opts := range secretOpts.Value() {
-
-		secretName := opts.SecretName
-		if _, exists := requestedSecrets[secretName]; exists {
-			return nil, fmt.Errorf("duplicate secret target for %s not allowed", secretName)
-		}
-
-		id, ok := foundSecrets[secretName]
-		if !ok {
-			return nil, fmt.Errorf("secret not found: %s; possible choices:\n%s", secretName, secrets)
-		}
-
-		options := new(swarm.SecretReference)
-		*options = *opts
-		options.SecretID = id
-
-		requestedSecrets[secretName] = true
-		values = append(values, options)
-	}
-
-	return values, nil
 }

--- a/handlers/secrets.go
+++ b/handlers/secrets.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/cli/opts"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
+)
+
+func makeSecretsArray(c *client.Client, secretNames []string) ([]*swarm.SecretReference, error) {
+	values := []*swarm.SecretReference{}
+
+	if len(secretNames) == 0 {
+		return values, nil
+	}
+
+	secretOpts := new(opts.SecretOpt)
+	for _, secret := range secretNames {
+		secretSpec := fmt.Sprintf("source=%s,target=/var/openfaas/secrets/%s", secret, secret)
+		if err := secretOpts.Set(secretSpec); err != nil {
+			return nil, err
+		}
+	}
+
+	requestedSecrets := make(map[string]bool)
+	ctx := context.Background()
+
+	// query the Swarm for the requested secret ids, these are required to complete
+	// the spec
+	args := filters.NewArgs()
+	for _, opt := range secretOpts.Value() {
+		args.Add("name", opt.SecretName)
+	}
+
+	secrets, err := c.SecretList(ctx, types.SecretListOptions{
+		Filters: args,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// create map of matching secrets for easy lookup
+	foundSecrets := make(map[string]string)
+	for _, secret := range secrets {
+		foundSecrets[secret.Spec.Annotations.Name] = secret.ID
+	}
+
+	// mimics the simple syntax for `docker service create --secret foo`
+	// and the code is based on the docker cli
+	for _, opts := range secretOpts.Value() {
+
+		secretName := opts.SecretName
+		if _, exists := requestedSecrets[secretName]; exists {
+			return nil, fmt.Errorf("duplicate secret target for %s not allowed", secretName)
+		}
+
+		id, ok := foundSecrets[secretName]
+		if !ok {
+			return nil, fmt.Errorf("secret not found: %s; possible choices:\n%s", secretName, secrets)
+		}
+
+		options := new(swarm.SecretReference)
+		*options = *opts
+		options.SecretID = id
+
+		requestedSecrets[secretName] = true
+		values = append(values, options)
+	}
+
+	return values, nil
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- change the secret configuration string spec to mount secrets in
/var/openfaas/secrets

## Description
<!--- Describe your changes in detail -->
Using a simple string format, this changes uses the docker cli parsing options to set the secret target to be in `/var/openfaas/secrets`.

This change also moves the secrets related methods (`makeSecretsArray`) to a separate `secrets.go` file to mimic the structure in the Kubernetes projects. Hopefully, this makes it easier to track changes across the projects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
This change will ensure that the secrets required for the function business logic do not interfere with standard locations that other systems may want to modify.

This also ensures a consistent experience for function deployment across
swarm and k8s

Implements openfaas/faas#692
Relates to openfaas/faas-netes#188



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this locally in Docker Swarm with a modified version of the [ApiKeyProtected-Secrets](https://github.com/openfaas/faas/tree/master/sample-functions/ApiKeyProtected-Secrets) example function. An updated docker image is available for testing at [theaxer/faas-swarm](https://hub.docker.com/r/theaxer/faas-swarm/)

I have not written any unit tests for this yet, because the method currently calls to the swarm api, so I need to research how to mock that interaction first. 


Changes will need to be made to the documentation and example functions in the [openfaas/faas](https://github.com/openfaas/faas) repo.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
