### PR TITLE
Do not expose internal label suffix

### DIFF
--- a/handlers/reader.go
+++ b/handlers/reader.go
@@ -92,7 +92,7 @@ func buildLabelsAndAnnotations(dockerLabels map[string]string) (labels map[strin
 				annotations = make(map[string]string)
 			}
 
-			annotations[k] = v
+			annotations[strings.TrimPrefix(k, annotationLabelPrefix)] = v
 		} else {
 			if labels == nil {
 				labels = make(map[string]string)

--- a/handlers/reader_test.go
+++ b/handlers/reader_test.go
@@ -57,7 +57,7 @@ func Test_BuildLabelsAndAnnotationsFromServiceSpec_Annotations(t *testing.T) {
 		t.Errorf("want: %d annotation got: %d", 1, len(annotation))
 	}
 
-	if _, ok := annotation[fmt.Sprintf("%scurrent-time", annotationLabelPrefix)]; !ok {
+	if _, ok := annotation["current-time"]; !ok {
 		t.Errorf("want: '%s' entry in annotation map got: key not found", "current-time")
 	}
 }


### PR DESCRIPTION
Resolves: #29

Signed-off-by: Edward Wilde <ewilde@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes an issue introduced with https://github.com/openfaas/faas-swarm/pull/28 annotations should not include the internal prefix used by faas-swarm to store the annotation as a label

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)) #29


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
