### PR TITLE
Update status code for CRUD operations

### DIFF
--- a/handlers/delete.go
+++ b/handlers/delete.go
@@ -71,7 +71,7 @@ func DeleteHandler(c *client.Client) http.HandlerFunc {
 			log.Println(serviceRemoveErrors)
 			w.WriteHeader(http.StatusInternalServerError)
 		} else {
-			w.WriteHeader(http.StatusOK)
+			w.WriteHeader(http.StatusAccepted)
 		}
 
 	}

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -97,6 +97,8 @@ func DeployHandler(c *client.Client, maxRestarts uint64, restartDelay time.Durat
 		if len(response.Warnings) > 0 {
 			log.Println(response.Warnings)
 		}
+
+		w.WriteHeader(http.StatusAccepted)
 	}
 }
 
@@ -362,7 +364,7 @@ func buildLabels(request *requests.CreateFunctionRequest) (map[string]string, er
 	}
 
 	if request.Annotations != nil {
-		for k,v := range *request.Annotations {
+		for k, v := range *request.Annotations {
 			key := fmt.Sprintf("%s%s", annotationLabelPrefix, k)
 			if _, ok := labels[key]; !ok {
 				labels[key] = v

--- a/handlers/replicas_updater.go
+++ b/handlers/replicas_updater.go
@@ -58,6 +58,7 @@ func ReplicaUpdater(c *client.Client) http.HandlerFunc {
 			return
 		}
 
+		w.WriteHeader(http.StatusAccepted)
 	}
 }
 

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -95,9 +95,12 @@ func UpdateHandler(c *client.Client, maxRestarts uint64, restartDelay time.Durat
 			w.Write([]byte("Update error: " + err.Error()))
 			return
 		}
+
 		if response.Warnings != nil {
 			log.Println(response.Warnings)
 		}
+
+		w.WriteHeader(http.StatusAccepted)
 	}
 }
 


### PR DESCRIPTION
This commit updates the status code from 200 to 202 for create, update
or delete APIs.

Fixes: #25

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes: #25 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on local swarm cluster.

```
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:24:45 Forwarded [PUT] to /system/functions - [404] - 0.007258 seconds
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:24:45 <nil>
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:24:45 Forwarded [POST] to /system/functions - [400] - 0.007525 seconds
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:24:45 Forwarded [PUT] to /system/functions - [404] - 0.003527 seconds
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:24:45 Forwarded [POST] to /system/functions - [400] - 0.005835 seconds
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:24:50 <nil>
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:24:55 <nil>
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:24:57 Forwarded [PUT] to /system/functions - [404] - 0.006341 seconds
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:24:57 Forwarded [POST] to /system/functions - [202] - 0.006329 seconds
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:24:57 Forwarded [PUT] to /system/functions - [404] - 0.003409 seconds
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:24:57 Forwarded [POST] to /system/functions - [202] - 0.004641 seconds
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:25:00 <nil>
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:25:05 <nil>
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:25:10 <nil>
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:25:11 Forwarded [PUT] to /system/functions - [202] - 0.012306 seconds
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:25:11 Forwarded [PUT] to /system/functions - [202] - 0.006914 seconds
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:25:15 <nil>
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:25:20 <nil>
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:25:25 <nil>
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:25:30 <nil>
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:25:35 <nil>
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:25:36 Forwarded [DELETE] to /system/functions - [202] - 0.008955 seconds
func_gateway.1.kvkck8zyiva2@linuxkit-025000000001    | 2018/09/22 09:25:36 Forwarded [DELETE] to /system/functions - [202] - 0.009504 seconds
```

```
faas-cli deploy --network=func_functions
Deploying: go-hello-world.

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/go-hello-world

Deploying: python-hello-word.

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/python-hello-word

➜  of-cloud-test-fn git:(master) ✗ faas-cli deploy --network=func_functions
Deploying: go-hello-world.

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/go-hello-world

Deploying: python-hello-word.

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/python-hello-word

➜  of-cloud-test-fn git:(master) ✗ faas-cli remove
Deleting: go-hello-world.
Removing old function.
Deleting: python-hello-word.
Removing old function.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
