### PR TITLE
Update to return empty set for Namespaces call

### DIFF
--- a/handlers/namespace.go
+++ b/handlers/namespace.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// Swarm does not use namespaces, so we return an empty list. see https://github.com/openfaas-incubator/connector-sdk/pull/46
+func NamespaceLister() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		namespaces := []string{}
+		nsJSON, err := json.Marshal(namespaces)
+
+		if err != nil {
+			log.Printf("Unable to marshal namespaces into JSON %q", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("\"error\": \"unable to return namespaces\""))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(nsJSON)
+	}
+}
+

--- a/main.go
+++ b/main.go
@@ -64,6 +64,8 @@ func main() {
 		InfoHandler:    handlers.MakeInfoHandler(version.BuildVersion(), version.GitCommit),
 		SecretHandler:  handlers.MakeSecretsHandler(dockerClient),
 		LogHandler:     logs.NewLogHandlerFunc(handlers.NewLogRequester(dockerClient), cfg.FaaSConfig.WriteTimeout),
+		ListNamespaceHandler: handlers.NamespaceLister(),
+
 	}
 
 	bootstrapConfig := bootTypes.FaaSConfig{


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The namespace call added to OpenFaaS was not implemented in
here, and that meant that calling it returned an empty response
rather than some valid json, A user noted that this caused an error
in the connector-sdk, which has had a fix added, but we need this
namespace endpoint to not return none (well it was actually erroring)

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## To upgrade:
We need to deploy new version of faas-swarm containers (for the arches we support), then update the docker-compose files in openfaas/faas 
A user should apply the update by running deploy_stack.sh / ps1 again

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
This change was requested in the below:
https://github.com/openfaas-incubator/connector-sdk/pull/46

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
deployed the new container onto swarm and called the endpoint, 
This is the container log:
<img width="639" alt="Screenshot 2019-12-14 at 15 07 51" src="https://user-images.githubusercontent.com/40488132/70850568-b38af980-1e83-11ea-8b64-e626ae7f3c89.png">


This is the empty list returned (beginning of second line)
<img width="805" alt="Screenshot 2019-12-14 at 15 08 20" src="https://user-images.githubusercontent.com/40488132/70850571-bab20780-1e83-11ea-88ba-791740c353a7.png">

Previously the container logs were 502 error, and nothing was returned: 

<img width="751" alt="Screenshot 2019-12-14 at 15 09 11" src="https://user-images.githubusercontent.com/40488132/70850579-d9180300-1e83-11ea-8479-2a8fe9344f6b.png">
<img width="890" alt="Screenshot 2019-12-14 at 15 08 54" src="https://user-images.githubusercontent.com/40488132/70850580-d9b09980-1e83-11ea-8411-243a57e41746.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
