### PR TITLE
Use license-check docker image instead of curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
+FROM teamserverless/license-check:0.3.6 as license-check
+
 FROM golang:1.11 as build
-RUN curl -sLSf https://raw.githubusercontent.com/teamserverless/license-check/master/get.sh | sh
-RUN mv ./license-check /usr/bin/license-check && chmod +x /usr/bin/license-check
+
+COPY --from=license-check /license-check /usr/bin/
 
 RUN mkdir -p /go/src/github.com/openfaas/faas-swarm/
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,6 +1,8 @@
+FROM teamserverless/license-check:0.3.6 as license-check
+
 FROM golang:1.11 as build
-RUN curl -sLSf https://raw.githubusercontent.com/teamserverless/license-check/master/get.sh | sh
-RUN mv ./license-check /usr/bin/license-check && chmod +x /usr/bin/license-check
+
+COPY --from=license-check /license-check /usr/bin/
 
 RUN mkdir -p /go/src/github.com/openfaas/faas-swarm/
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,6 +1,8 @@
+FROM teamserverless/license-check:0.3.6 as license-check
+
 FROM golang:1.11 as build
-RUN curl -sLSf https://raw.githubusercontent.com/teamserverless/license-check/master/get.sh | sh
-RUN mv ./license-check /usr/bin/license-check && chmod +x /usr/bin/license-check
+
+COPY --from=license-check /license-check /usr/bin/
 
 RUN mkdir -p /go/src/github.com/openfaas/faas-swarm/
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Optimizes Docker builds by copying from license-check Docker image instead of using curl to download the tool.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Ref: https://github.com/openfaas/faas/issues/1440

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`make build` and all containers passed license-check

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
